### PR TITLE
Update ds106bank.css

### DIFF
--- a/wp-content/themes/ds106banker/ds106bank.css
+++ b/wp-content/themes/ds106banker/ds106bank.css
@@ -124,6 +124,7 @@ p.wp-caption-text {
   margin: auto;
   position: absolute;
   top: 0; left: 0; bottom: 0; right: 0;
+  border: 0px;
 }
 
 


### PR DESCRIPTION
Add "border: 0px;" to "thing-icon img"

So this is an interesting one. The white border on the actual assignment is being pulled in on the image as well. This creates a very mildly annoyance at best, but I thought it would be worth sharing how I've fixed this by telling the CSS to have no border on the image. Here are screenshots from before and after. You'll see that the image now bleeds to the edge of the assignment box.

![Before and after](https://cloud.githubusercontent.com/assets/11494815/15291954/454e9736-1b46-11e6-9d70-cf1016777a4b.png)
