### PR TITLE
Address 'invalid taxonomy' error raising.

### DIFF
--- a/wp-content/themes/ds106banker/functions.php
+++ b/wp-content/themes/ds106banker/functions.php
@@ -389,7 +389,8 @@ function update_assignment_tags( $post_id ) {
 		
 	// make a tag for the type of assignment, assign to both taxonomies
 	// for assignment examples and tutorials
-	if ( count( $assignmenttype_terms ) ) {
+	if ( (! isset( $assignmenttype_terms->errors ) )
+		 && count( $assignmenttype_terms ) ) {
 		$assignment_type = $assignmenttype_terms[0]->name . THINGNAME;
 		wp_set_object_terms( $post_id, $assignment_type , 'assignmenttags');
 		wp_set_object_terms( $post_id, $assignment_type , 'tutorialtags');


### PR DESCRIPTION
I don't know if this is of use / interest to you, or whether it's just masking a bug outside of this code, but I added this to address an issue that came up in publishing a couple of Quests today.